### PR TITLE
Use default HttpClientHandler when there is no kurrentdb cert

### DIFF
--- a/src/Linker.Core/LinkerConnectionBuilder.cs
+++ b/src/Linker.Core/LinkerConnectionBuilder.cs
@@ -15,14 +15,16 @@ public class LinkerConnectionBuilder(
     public KurrentDBClient Build()
     {
         ConnectionSettings.DefaultDeadline = TimeSpan.FromSeconds(30);
-        ConnectionSettings.CreateHttpMessageHandler = () =>
+        if (cert != null)
         {
-            var handler = new HttpClientHandler();
-            if (cert == null) return handler;
-            handler.ClientCertificates.Add(cert);
-            handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
-            return handler;
-        };
+            ConnectionSettings.CreateHttpMessageHandler = () =>
+            {
+                var handler = new HttpClientHandler();
+                handler.ClientCertificates.Add(cert);
+                handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+                return handler;
+            };
+        }
         return new KurrentDBClient(ConnectionSettings);
     }
 }


### PR DESCRIPTION
Don't override the HttpClientHandler when a client certificate is not provided.
Previously, a custom handler was always injected, even when no certificate was configured which breaks the default .NET HTTP/2 and TLS behaviour required for the gRPC connection.

Error:
`Thursday, 02 April 2026 08:58:48|PositionRepository|Error while initializing stream
Thursday, 02 April 2026 08:58:48|PositionRepository|Status(StatusCode="Internal", Detail="Error starting gRPC call. HttpRequestException: The SSL connection could not be established, see inner exception. AuthenticationException: The remote certificate is invalid according to the validation procedure: RemoteCertificateNameMismatch", DebugException="System.Net.Http.HttpRequestException: The SSL connection could not be established, see inner exception.")
2026-04-02 08:58:48.914 info: Linker.ReplicaApp[0] Found 1 services to start
2026-04-02 08:58:48.914 info: Linker.ReplicaApp[0] Starting From-source-catchup01-To-sink-catchup01
Thursday, 02 April 2026 08:58:49|PositionRepository|Error while reading the position: The remote certificate is invalid according to the validation procedure: RemoteCertificateNameMismatch`