### PR TITLE
Catchup resilience and throughput

### DIFF
--- a/src/Linker.Core/LinkerService.cs
+++ b/src/Linker.Core/LinkerService.cs
@@ -18,8 +18,15 @@ public class LinkerService : ILinkerService, IAsyncDisposable
     private readonly IFilterService? _filterService;
     private readonly Settings _settings;
     private Position _lastPosition;
+    private readonly Lock _positionLock = new();
     private Position _originCurrentEnd = Position.Start;
     public string Name { get; }
+
+    private Position LastPosition
+    {
+        get { lock (_positionLock) return _lastPosition; }
+        set { lock (_positionLock) _lastPosition = value; }
+    }
 
     private readonly ILinkerConnectionBuilder _originConnectionBuilder;
     private readonly ILinkerConnectionBuilder _destinationConnectionBuilder;
@@ -51,6 +58,7 @@ public class LinkerService : ILinkerService, IAsyncDisposable
     public const int MaxAllowedBuffer = 1000;
     public const int MinAllowedBuffer = 1;
     private const int StatsIntervalMs = 3000;
+    private static readonly TimeSpan ResubscribeDelay = TimeSpan.FromSeconds(5);
 
     private readonly ConcurrentDictionary<string, SortedDictionary<ulong, BufferedEvent>> _perStreamBuffers = new();
     private readonly ConcurrentDictionary<string, ulong?> _lastWrittenPerStream = new();
@@ -135,6 +143,9 @@ public class LinkerService : ILinkerService, IAsyncDisposable
         foreach (var evt in buffered)
             await _channel.Writer.WriteAsync(evt);
 
+        _cts.Dispose();
+        _cts = new CancellationTokenSource();
+
         StartWorkerTasks();
     }
 
@@ -155,8 +166,9 @@ public class LinkerService : ILinkerService, IAsyncDisposable
 
         _cts = new CancellationTokenSource();
 
-        if (!_positionRepository.TryGet(out _lastPosition))
-            _lastPosition = Position.Start;
+        if (!_positionRepository.TryGet(out var storedPosition))
+            storedPosition = Position.Start;
+        LastPosition = storedPosition;
 
         _adjustedStartStreams.Clear();
         var loaded = await _adjustedStreamRepository.LoadAsync();
@@ -346,6 +358,9 @@ public class LinkerService : ILinkerService, IAsyncDisposable
 
         _logger.LogTrace($"{Name}: LastWritten={(lastWritten.HasValue ? lastWritten.Value.ToString() : "null")}, Expected={expected}, BufferCount={buffer.Count}");
         _logger.LogTrace($"{Name}: Buffer keys: {string.Join(",", buffer.Keys)}");
+
+        foreach (var stale in buffer.Keys.Where(k => k < expected).ToList())
+            buffer.Remove(stale);
         
         if (!buffer.ContainsKey(expected))
             _logger.LogDebug($"{Name}: Missing expected event {expected}@{streamId}, can't append");
@@ -378,21 +393,41 @@ public class LinkerService : ILinkerService, IAsyncDisposable
     {
         if (_originConnection == null)
             throw new Exception("Origin connection is not initialized");
-        await using var subscription = _originConnection.SubscribeToAll(start: FromAll.After(_lastPosition), cancellationToken: ctsToken,
-            resolveLinkTos: _settings.ResolveLinkTos, filterOptions: new SubscriptionFilterOptions(EventTypeFilter.RegularExpression(@"^(\$metadata|[^\$].*)")));
-        await foreach (var message in subscription.Messages.WithCancellation(ctsToken))
+
+        while (!ctsToken.IsCancellationRequested)
         {
-            var currentBuffer = _channel.Reader.Count;
-            var threshold = _currentBackpressureThreshold;
-
-            if (currentBuffer >= _bufferSize * threshold)
+            try
             {
-                _logger.LogDebug($"{Name}: Backpressure active. Buffer={currentBuffer}/{_bufferSize}, Threshold={threshold:P0}");
-                await Task.Delay(100, ctsToken);
-            }
+                await using var subscription = _originConnection.SubscribeToAll(start: FromAll.After(LastPosition), cancellationToken: ctsToken,
+                    resolveLinkTos: _settings.ResolveLinkTos, filterOptions: new SubscriptionFilterOptions(EventTypeFilter.RegularExpression(@"^(\$metadata|[^\$].*)")));
+                await foreach (var message in subscription.Messages.WithCancellation(ctsToken))
+                {
+                    var currentBuffer = _channel.Reader.Count;
+                    var threshold = _currentBackpressureThreshold;
 
-            if (message is StreamMessage.Event(var evnt))
-                await HandleEventAsync(evnt);
+                    if (currentBuffer >= _bufferSize * threshold)
+                    {
+                        _logger.LogDebug($"{Name}: Backpressure active. Buffer={currentBuffer}/{_bufferSize}, Threshold={threshold:P0}");
+                        await Task.Delay(100, ctsToken);
+                    }
+
+                    if (message is StreamMessage.Event(var evnt))
+                        await HandleEventAsync(evnt);
+                }
+
+                _logger.LogWarning("{Name}: Subscription completed unexpectedly at position {Position}; resubscribing in {Delay}s", Name, LastPosition, ResubscribeDelay.TotalSeconds);
+                await Task.Delay(ResubscribeDelay, ctsToken);
+            }
+            catch (OperationCanceledException) when (ctsToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "{Name}: Subscription dropped at position {Position}; resubscribing in {Delay}s", Name, LastPosition, ResubscribeDelay.TotalSeconds);
+                try { await Task.Delay(ResubscribeDelay, ctsToken); }
+                catch (OperationCanceledException) { break; }
+            }
         }
     }
 
@@ -416,7 +451,7 @@ public class LinkerService : ILinkerService, IAsyncDisposable
         if (!_replicaHelper.TryProcessMetadata(evt.Event.EventStreamId, evt.Event.EventNumber, evt.Event.Created,
                 _originConnectionBuilder.ConnectionName, metadata, out var enrichedMetadata))
         {
-            _logger.LogDebug($"{Name}: Updated global last position to {_lastPosition}");
+            _logger.LogDebug($"{Name}: Updated global last position to {LastPosition}");
             return;
         }
 
@@ -581,8 +616,8 @@ public class LinkerService : ILinkerService, IAsyncDisposable
         try
         {
             await _destinationConnection.AppendToStreamAsync(evt.StreamId, expectedRevision, [evt.EventData]);
-            _lastPosition = evt.OriginalPosition;
-            _positionRepository.Set(_lastPosition);
+            LastPosition = evt.OriginalPosition;
+            _positionRepository.Set(evt.OriginalPosition);
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("eventStreamId"))
         {
@@ -720,8 +755,8 @@ public class LinkerService : ILinkerService, IAsyncDisposable
             });
             Interlocked.Increment(ref _replicatedSinceLastStats);
             Interlocked.Increment(ref _replicatedTotal);
-            _lastPosition = evt.OriginalPosition;
-            _positionRepository.Set(_lastPosition);
+            LastPosition = evt.OriginalPosition;
+            _positionRepository.Set(evt.OriginalPosition);
             return true;
         }
         catch (Exception innerEx)
@@ -745,10 +780,11 @@ public class LinkerService : ILinkerService, IAsyncDisposable
         }
 
         double progressPercent = 0;
-        if (_originCurrentEnd > Position.Start && _lastPosition > Position.Start)
+        var lastPosition = LastPosition;
+        if (_originCurrentEnd > Position.Start && lastPosition > Position.Start)
         {
             var origin = _originCurrentEnd.CommitPosition + _originCurrentEnd.PreparePosition;
-            var current = _lastPosition.CommitPosition + _lastPosition.PreparePosition;
+            var current = lastPosition.CommitPosition + lastPosition.PreparePosition;
             if (origin > 0)
                 progressPercent = Math.Min(100, (double)current / origin * 100);
         }
@@ -818,7 +854,7 @@ public class LinkerService : ILinkerService, IAsyncDisposable
         ["from"] = _originConnectionBuilder.ConnectionName,
         ["to"] = _destinationConnectionBuilder.ConnectionName,
         ["isRunning"] = _started,
-        ["lastPosition"] = _lastPosition,
+        ["lastPosition"] = LastPosition,
         ["bufferedEvents"] = _channel.Reader.Count,
         ["replicatedTotal"] = Interlocked.Read(ref _replicatedTotal)
     };

--- a/src/Linker.Core/LinkerService.cs
+++ b/src/Linker.Core/LinkerService.cs
@@ -18,14 +18,27 @@ public class LinkerService : ILinkerService, IAsyncDisposable
     private readonly IFilterService? _filterService;
     private readonly Settings _settings;
     private Position _lastPosition;
+    private Position _scanPosition;
     private readonly Lock _positionLock = new();
     private Position _originCurrentEnd = Position.Start;
+    private volatile bool _isLive;
+    private ulong _previousScanCommit;
+    private DateTime _previousScanSampleAt;
+    private double _scanRatePerSecond;
+    private int _stalledIntervals;
+    private int _originEndRefreshCounter;
     public string Name { get; }
 
     private Position LastPosition
     {
         get { lock (_positionLock) return _lastPosition; }
         set { lock (_positionLock) _lastPosition = value; }
+    }
+
+    private Position ScanPosition
+    {
+        get { lock (_positionLock) return _scanPosition; }
+        set { lock (_positionLock) _scanPosition = value; }
     }
 
     private readonly ILinkerConnectionBuilder _originConnectionBuilder;
@@ -169,6 +182,11 @@ public class LinkerService : ILinkerService, IAsyncDisposable
         if (!_positionRepository.TryGet(out var storedPosition))
             storedPosition = Position.Start;
         LastPosition = storedPosition;
+        ScanPosition = storedPosition;
+        _isLive = false;
+        _previousScanSampleAt = default;
+        _scanRatePerSecond = 0;
+        _stalledIntervals = 0;
 
         _adjustedStartStreams.Clear();
         var loaded = await _adjustedStreamRepository.LoadAsync();
@@ -398,21 +416,39 @@ public class LinkerService : ILinkerService, IAsyncDisposable
         {
             try
             {
+                _isLive = false;
                 await using var subscription = _originConnection.SubscribeToAll(start: FromAll.After(LastPosition), cancellationToken: ctsToken,
                     resolveLinkTos: _settings.ResolveLinkTos, filterOptions: new SubscriptionFilterOptions(EventTypeFilter.RegularExpression(@"^(\$metadata|[^\$].*)")));
                 await foreach (var message in subscription.Messages.WithCancellation(ctsToken))
                 {
-                    var currentBuffer = _channel.Reader.Count;
-                    var threshold = _currentBackpressureThreshold;
-
-                    if (currentBuffer >= _bufferSize * threshold)
+                    switch (message)
                     {
-                        _logger.LogDebug($"{Name}: Backpressure active. Buffer={currentBuffer}/{_bufferSize}, Threshold={threshold:P0}");
-                        await Task.Delay(100, ctsToken);
-                    }
+                        case StreamMessage.Event(var evnt):
+                            var currentBuffer = _channel.Reader.Count;
+                            var threshold = _currentBackpressureThreshold;
 
-                    if (message is StreamMessage.Event(var evnt))
-                        await HandleEventAsync(evnt);
+                            if (currentBuffer >= _bufferSize * threshold)
+                            {
+                                _logger.LogDebug($"{Name}: Backpressure active. Buffer={currentBuffer}/{_bufferSize}, Threshold={threshold:P0}");
+                                await Task.Delay(100, ctsToken);
+                            }
+
+                            await HandleEventAsync(evnt);
+                            if (evnt.OriginalPosition.HasValue)
+                                ScanPosition = evnt.OriginalPosition.Value;
+                            break;
+                        case StreamMessage.AllStreamCheckpointReached(var checkpoint):
+                            ScanPosition = checkpoint;
+                            break;
+                        case StreamMessage.CaughtUp:
+                            _isLive = true;
+                            _logger.LogInformation("{Name}: Caught up with origin — subscription is now live", Name);
+                            break;
+                        case StreamMessage.FellBehind:
+                            _isLive = false;
+                            _logger.LogInformation("{Name}: Fell behind origin — catching up again", Name);
+                            break;
+                    }
                 }
 
                 _logger.LogWarning("{Name}: Subscription completed unexpectedly at position {Position}; resubscribing in {Delay}s", Name, LastPosition, ResubscribeDelay.TotalSeconds);
@@ -779,16 +815,6 @@ public class LinkerService : ILinkerService, IAsyncDisposable
             avgLatency = _latencySamples.Count > 0 ? (long)_latencySamples.Average() : 0;
         }
 
-        double progressPercent = 0;
-        var lastPosition = LastPosition;
-        if (_originCurrentEnd > Position.Start && lastPosition > Position.Start)
-        {
-            var origin = _originCurrentEnd.CommitPosition + _originCurrentEnd.PreparePosition;
-            var current = lastPosition.CommitPosition + lastPosition.PreparePosition;
-            if (origin > 0)
-                progressPercent = Math.Min(100, (double)current / origin * 100);
-        }
-
         lock (_adaptiveLock)
         {
             _replicationSamples.Add(replicatedThisInterval);
@@ -805,40 +831,89 @@ public class LinkerService : ILinkerService, IAsyncDisposable
 
                 if (average == 0 && previous == 0)
                 {
-                    _logger.LogInformation($"{Name} adaptive tuning skipped: no replication activity. Current BufferSize={_bufferSize}");
-                    return;
-                }
-
-                var percentChange = previous == 0 ? 1 : (average - previous) / previous;
-                var proposed = _bufferSize;
-
-                if (_settings.AutomaticTuning)
-                {
-                    var delta = Math.Max(1, (int)Math.Round(_bufferSize * _allowedIncreaseOrDecreaseAmount));
-
-                    if (percentChange >= _significantIncreaseToTriggerIncrease)
-                    {
-                        // Steady or improving: increase buffer
-                        proposed = Math.Min(MaxAllowedBuffer, _bufferSize + delta);
-                    }
-                    else if (percentChange < _significantRegressionToTriggerDecrease)
-                    {
-                        // Significant regression: decrease buffer
-                        proposed = Math.Max(MinAllowedBuffer, _bufferSize - delta);
-                    }
-
-                    if (proposed != _bufferSize)
-                        _ = ResizeChannelAsync(proposed);
-
-                    _logger.LogInformation($"{Name} adaptive tuning: prevAvg={previous:F1}, currentAvg={average:F1}, proposed bufferSize={proposed}, change={percentChange:P1}");
+                    _logger.LogDebug($"{Name} adaptive tuning skipped: no replication activity. Current BufferSize={_bufferSize}");
                 }
                 else
-                    _logger.LogInformation($"{Name} prevAvg={previous:F1}, currentAvg={average:F1}, bufferSize={proposed}, change={percentChange:P1}");
+                {
+                    var percentChange = previous == 0 ? 1 : (average - previous) / previous;
+                    var proposed = _bufferSize;
+
+                    if (_settings.AutomaticTuning)
+                    {
+                        var delta = Math.Max(1, (int)Math.Round(_bufferSize * _allowedIncreaseOrDecreaseAmount));
+
+                        if (percentChange >= _significantIncreaseToTriggerIncrease)
+                        {
+                            // Steady or improving: increase buffer
+                            proposed = Math.Min(MaxAllowedBuffer, _bufferSize + delta);
+                        }
+                        else if (percentChange < _significantRegressionToTriggerDecrease)
+                        {
+                            // Significant regression: decrease buffer
+                            proposed = Math.Max(MinAllowedBuffer, _bufferSize - delta);
+                        }
+
+                        if (proposed != _bufferSize)
+                        {
+                            _ = ResizeChannelAsync(proposed);
+                            _logger.LogInformation($"{Name} adaptive tuning: prevAvg={previous:F1}, currentAvg={average:F1}, proposed bufferSize={proposed}, change={percentChange:P1}");
+                        }
+                        else
+                            _logger.LogDebug($"{Name} adaptive tuning: prevAvg={previous:F1}, currentAvg={average:F1}, proposed bufferSize={proposed}, change={percentChange:P1}");
+                    }
+                    else
+                        _logger.LogDebug($"{Name} prevAvg={previous:F1}, currentAvg={average:F1}, bufferSize={proposed}, change={percentChange:P1}");
+                }
             }
         }
 
+        var status = BuildProgressStatus();
+
         _logger.LogInformation(
-            $"{Name} stats: replicated {replicatedThisInterval} events, total: {totalReplicated}, buffer: {bufferSize}/{_bufferSize} ({bufferRatio:P0}), latency: {avgLatency}ms, progress: {progressPercent:F1}%");
+            $"{Name} stats: {status}, replicated {replicatedThisInterval} events (total {totalReplicated}), buffer: {bufferSize}/{_bufferSize} ({bufferRatio:P0}), latency: {avgLatency}ms");
+
+        if (++_originEndRefreshCounter >= 10)
+        {
+            _originEndRefreshCounter = 0;
+            _ = UpdateOriginCurrentEndAsync();
+        }
+    }
+
+    private string BuildProgressStatus()
+    {
+        if (_isLive)
+            return "live";
+
+        var scanCommit = ScanPosition.CommitPosition;
+        var originEndCommit = _originCurrentEnd.CommitPosition;
+
+        double scanPercent = 0;
+        if (originEndCommit > 0)
+            scanPercent = Math.Min(100, (double)scanCommit / originEndCommit * 100);
+
+        var now = DateTime.UtcNow;
+        if (_previousScanSampleAt != default && now > _previousScanSampleAt && scanCommit >= _previousScanCommit)
+        {
+            var rate = (scanCommit - _previousScanCommit) / (now - _previousScanSampleAt).TotalSeconds;
+            _scanRatePerSecond = _scanRatePerSecond == 0 ? rate : _scanRatePerSecond * 0.7 + rate * 0.3;
+            _stalledIntervals = scanCommit == _previousScanCommit ? _stalledIntervals + 1 : 0;
+        }
+        _previousScanCommit = scanCommit;
+        _previousScanSampleAt = now;
+
+        var status = $"catching up {scanPercent:F1}%";
+        if (_stalledIntervals >= 3)
+            return status + $", STALLED (no scan progress for {_stalledIntervals * StatsIntervalMs / 1000}s)";
+
+        if (_scanRatePerSecond > 0 && originEndCommit > scanCommit)
+        {
+            var eta = TimeSpan.FromSeconds((originEndCommit - scanCommit) / _scanRatePerSecond);
+            status += eta.TotalHours >= 1
+                ? $", ETA {(int)eta.TotalHours}h{eta.Minutes:D2}m"
+                : $", ETA {eta.Minutes}m{eta.Seconds:D2}s";
+        }
+
+        return status;
     }
 
     private async Task RestartServiceAsync()
@@ -854,7 +929,10 @@ public class LinkerService : ILinkerService, IAsyncDisposable
         ["from"] = _originConnectionBuilder.ConnectionName,
         ["to"] = _destinationConnectionBuilder.ConnectionName,
         ["isRunning"] = _started,
+        ["isLive"] = _isLive,
         ["lastPosition"] = LastPosition,
+        ["scanPosition"] = ScanPosition,
+        ["originEnd"] = _originCurrentEnd,
         ["bufferedEvents"] = _channel.Reader.Count,
         ["replicatedTotal"] = Interlocked.Read(ref _replicatedTotal)
     };

--- a/src/Linker.Core/LinkerService.cs
+++ b/src/Linker.Core/LinkerService.cs
@@ -59,7 +59,6 @@ public class LinkerService : ILinkerService, IAsyncDisposable
     private long _replicatedSinceLastStats;
     private long _replicatedTotal;
 
-    private readonly double _currentBackpressureThreshold = 0.8;
     private readonly List<long> _latencySamples = [];
     private readonly List<long> _replicationSamples = [];
     private readonly Lock _adaptiveLock = new();
@@ -71,7 +70,13 @@ public class LinkerService : ILinkerService, IAsyncDisposable
     public const int MaxAllowedBuffer = 1000;
     public const int MinAllowedBuffer = 1;
     private const int StatsIntervalMs = 3000;
+    private const int MaxAppendBatchSize = 100;
+    private const int MaxAppendBatchBytes = 256 * 1024;
+    private const int MaxConcurrentStreamAppends = 8;
     private static readonly TimeSpan ResubscribeDelay = TimeSpan.FromSeconds(5);
+    private readonly SemaphoreSlim _appendConcurrency = new(MaxConcurrentStreamAppends, MaxConcurrentStreamAppends);
+    private readonly Lock _adjustedLock = new();
+    private readonly SemaphoreSlim _adjustedSaveLock = new(1, 1);
 
     private readonly ConcurrentDictionary<string, SortedDictionary<ulong, BufferedEvent>> _perStreamBuffers = new();
     private readonly ConcurrentDictionary<string, ulong?> _lastWrittenPerStream = new();
@@ -188,11 +193,14 @@ public class LinkerService : ILinkerService, IAsyncDisposable
         _scanRatePerSecond = 0;
         _stalledIntervals = 0;
 
-        _adjustedStartStreams.Clear();
         var loaded = await _adjustedStreamRepository.LoadAsync();
-        foreach (var s in loaded)
-            _adjustedStartStreams.Add(s);
-        _logger.LogInformation($"{Name}: Loaded {_adjustedStartStreams.Count} adjusted start streams from disk");
+        lock (_adjustedLock)
+        {
+            _adjustedStartStreams.Clear();
+            foreach (var s in loaded)
+                _adjustedStartStreams.Add(s);
+        }
+        _logger.LogInformation($"{Name}: Loaded {loaded.Count} adjusted start streams from disk");
 
         _destinationConnection = _destinationConnectionBuilder.Build();
         _originConnection = _originConnectionBuilder.Build();
@@ -340,7 +348,8 @@ public class LinkerService : ILinkerService, IAsyncDisposable
         _logger.LogDebug($"{Name}: Channel processing started");
         try
         {
-            await foreach (var evt in _channel.Reader.ReadAllAsync(_cts.Token))
+            var streams = new List<string>();
+            while (await _channel.Reader.WaitToReadAsync(_cts.Token))
             {
                 if (_forceChannelException)
                 {
@@ -348,8 +357,28 @@ public class LinkerService : ILinkerService, IAsyncDisposable
                     throw new Exception("Simulated test exception in ProcessChannelEventsAsync");
                 }
 
-                _logger.LogTrace($"{Name}: Dequeued {evt.EventNumber}@{evt.StreamId}");
-                await ProcessBufferedEvent(evt);
+                streams.Clear();
+                while (_channel.Reader.TryRead(out var evt))
+                {
+                    _logger.LogTrace($"{Name}: Dequeued {evt.EventNumber}@{evt.StreamId}");
+                    var buffer = _perStreamBuffers.GetOrAdd(evt.StreamId, _ => new SortedDictionary<ulong, BufferedEvent>());
+                    buffer[evt.EventNumber.ToUInt64()] = evt;
+                    if (!streams.Contains(evt.StreamId))
+                        streams.Add(evt.StreamId);
+                }
+
+                var appendedPositions = await Task.WhenAll(streams.Select(DrainStreamBufferAsync));
+
+                Position? maxAppended = null;
+                foreach (var position in appendedPositions)
+                    if (position.HasValue && (maxAppended == null || position.Value > maxAppended.Value))
+                        maxAppended = position;
+
+                if (maxAppended.HasValue && maxAppended.Value > LastPosition)
+                {
+                    LastPosition = maxAppended.Value;
+                    _positionRepository.Set(maxAppended.Value);
+                }
             }
         }
         catch (OperationCanceledException) { }
@@ -360,51 +389,185 @@ public class LinkerService : ILinkerService, IAsyncDisposable
         }
     }
 
-    private async Task ProcessBufferedEvent(BufferedEvent evt)
+    private async Task<Position?> DrainStreamBufferAsync(string streamId)
     {
-        var streamId = evt.StreamId;
-        var eventNum = evt.EventNumber.ToUInt64();
+        if (!_perStreamBuffers.TryGetValue(streamId, out var buffer))
+            return null;
 
-        var buffer = _perStreamBuffers.GetOrAdd(streamId, _ => new SortedDictionary<ulong, BufferedEvent>());
-        buffer[eventNum] = evt;
-
-        ulong expected;
-        if (_lastWrittenPerStream.TryGetValue(streamId, out var lastWritten))
-            expected = (lastWritten.HasValue ? lastWritten.Value + 1 : 0);
-        else
-            expected = 0;
+        var tracked = _lastWrittenPerStream.TryGetValue(streamId, out var lastWritten);
+        var expected = tracked && lastWritten.HasValue ? lastWritten.Value + 1 : 0;
 
         _logger.LogTrace($"{Name}: LastWritten={(lastWritten.HasValue ? lastWritten.Value.ToString() : "null")}, Expected={expected}, BufferCount={buffer.Count}");
         _logger.LogTrace($"{Name}: Buffer keys: {string.Join(",", buffer.Keys)}");
 
         foreach (var stale in buffer.Keys.Where(k => k < expected).ToList())
             buffer.Remove(stale);
-        
-        if (!buffer.ContainsKey(expected))
+
+        if (buffer.Count > 0 && !buffer.ContainsKey(expected))
             _logger.LogDebug($"{Name}: Missing expected event {expected}@{streamId}, can't append");
 
-        while (buffer.TryGetValue(expected, out var next))
+        var run = new List<BufferedEvent>();
+        for (var next = expected; buffer.TryGetValue(next, out var evt); next++)
+            run.Add(evt);
+
+        Position? maxAppended = null;
+        if (run.Count > 0)
         {
-            await AppendEventAsync(next);
-            _lastWrittenPerStream[streamId] = expected;
-            _flusherForStreamPositions.Update(streamId, expected);
-            if (expected == 0)
-                await _flusherForStreamPositions.FlushAsync();
-            buffer.Remove(expected);
-            expected++;
+            await _appendConcurrency.WaitAsync(_cts.Token);
+            try
+            {
+                if (tracked && !IsAdjustedStream(streamId))
+                    maxAppended = await AppendRunAsync(streamId, run, lastWritten);
+                else
+                    await AppendRunEventByEventAsync(streamId, run);
+            }
+            finally
+            {
+                _appendConcurrency.Release();
+            }
+
+            foreach (var evt in run)
+                buffer.Remove(evt.EventNumber.ToUInt64());
         }
 
         if (buffer.Count == 0)
             _perStreamBuffers.TryRemove(streamId, out _);
+
+        return maxAppended;
+    }
+
+    private async Task AppendRunEventByEventAsync(string streamId, IEnumerable<BufferedEvent> run)
+    {
+        foreach (var evt in run)
+        {
+            await AppendEventAsync(evt);
+            var eventNumber = evt.EventNumber.ToUInt64();
+            _lastWrittenPerStream[streamId] = eventNumber;
+            _flusherForStreamPositions.Update(streamId, eventNumber);
+            if (eventNumber == 0)
+                await _flusherForStreamPositions.FlushAsync();
+        }
+    }
+
+    private async Task<Position?> AppendRunAsync(string streamId, List<BufferedEvent> run, ulong? lastWritten)
+    {
+        if (_destinationConnection == null)
+            throw new InvalidOperationException("Destination connection is not initialized");
+
+        Position? maxAppended = null;
+        var repaired = false;
+        var start = 0;
+        while (start < run.Count)
+        {
+            var chunk = new List<BufferedEvent>();
+            long chunkBytes = 0;
+            while (start + chunk.Count < run.Count && chunk.Count < MaxAppendBatchSize)
+            {
+                var evt = run[start + chunk.Count];
+                chunkBytes += evt.EventData.Data.Length + evt.EventData.Metadata.Length;
+                if (chunk.Count > 0 && chunkBytes > MaxAppendBatchBytes)
+                    break;
+                chunk.Add(evt);
+            }
+
+            var expectedRevision = lastWritten.HasValue
+                ? StreamState.StreamRevision(lastWritten.Value)
+                : StreamState.NoStream;
+
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                await _destinationConnection.AppendToStreamAsync(streamId, expectedRevision,
+                    chunk.Select(e => e.EventData));
+            }
+            catch (WrongExpectedVersionException)
+            {
+                if (!repaired)
+                {
+                    repaired = true;
+                    var lastInDest = await GetLastEventFromAStreamAsync(streamId);
+                    var actual = lastInDest?.OriginalEventNumber.ToUInt64();
+                    _logger.LogWarning($"{Name}: Tracked position for {streamId} was stale (expected last {lastWritten?.ToString() ?? "none"}, destination has {actual?.ToString() ?? "none"}); repaired and retrying");
+                    _lastWrittenPerStream[streamId] = actual;
+                    if (actual.HasValue)
+                        _flusherForStreamPositions.Update(streamId, actual.Value);
+                    lastWritten = actual;
+                    while (start < run.Count && actual.HasValue && run[start].EventNumber.ToUInt64() <= actual.Value)
+                        start++;
+                    continue;
+                }
+
+                _logger.LogWarning($"{Name}: Batch append conflict on {streamId} persists after repair; retrying event by event");
+                await AppendRunEventByEventAsync(streamId, run.Skip(start));
+                return maxAppended;
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("eventStreamId"))
+            {
+                _logger.LogWarning(ex, $"{Name}: Batch append rejected for {streamId}; retrying event by event");
+                await AppendRunEventByEventAsync(streamId, run.Skip(start));
+                return maxAppended;
+            }
+            sw.Stop();
+
+            lock (_latencySamples)
+            {
+                _latencySamples.Add(sw.ElapsedMilliseconds);
+                if (_latencySamples.Count > 100) _latencySamples.RemoveAt(0);
+            }
+
+            var lastEvent = chunk[^1];
+            maxAppended = lastEvent.OriginalPosition;
+
+            var lastNumber = lastEvent.EventNumber.ToUInt64();
+            _lastWrittenPerStream[streamId] = lastNumber;
+            _flusherForStreamPositions.Update(streamId, lastNumber);
+            if (!lastWritten.HasValue)
+                await _flusherForStreamPositions.FlushAsync();
+
+            Interlocked.Add(ref _replicatedSinceLastStats, chunk.Count);
+            Interlocked.Add(ref _replicatedTotal, chunk.Count);
+
+            lastWritten = lastNumber;
+            start += chunk.Count;
+        }
+
+        return maxAppended;
+    }
+
+    private bool IsAdjustedStream(string streamId)
+    {
+        lock (_adjustedLock)
+            return _adjustedStartStreams.Contains(streamId);
+    }
+
+    private async Task SaveAdjustedStreamsAsync()
+    {
+        HashSet<string> snapshot;
+        lock (_adjustedLock)
+            snapshot = [.._adjustedStartStreams];
+
+        await _adjustedSaveLock.WaitAsync();
+        try
+        {
+            await _adjustedStreamRepository.SaveAsync(snapshot);
+        }
+        finally
+        {
+            _adjustedSaveLock.Release();
+        }
     }
 
     private async Task AddToAdjustedStreams(string streamId)
     {
-        var updated = _adjustedStartStreams.Add(streamId) ||
+        bool updated;
+        lock (_adjustedLock)
+        {
+            updated = _adjustedStartStreams.Add(streamId) ||
                       !streamId.StartsWith("$$") && _adjustedStartStreams.Add("$$" + streamId);
+        }
 
         if (updated)
-            await _adjustedStreamRepository.SaveAsync(_adjustedStartStreams);
+            await SaveAdjustedStreamsAsync();
     }
 
     private async Task SubscribeMeGrpc(CancellationToken ctsToken)
@@ -424,15 +587,6 @@ public class LinkerService : ILinkerService, IAsyncDisposable
                     switch (message)
                     {
                         case StreamMessage.Event(var evnt):
-                            var currentBuffer = _channel.Reader.Count;
-                            var threshold = _currentBackpressureThreshold;
-
-                            if (currentBuffer >= _bufferSize * threshold)
-                            {
-                                _logger.LogDebug($"{Name}: Backpressure active. Buffer={currentBuffer}/{_bufferSize}, Threshold={threshold:P0}");
-                                await Task.Delay(100, ctsToken);
-                            }
-
                             await HandleEventAsync(evnt);
                             if (evnt.OriginalPosition.HasValue)
                                 ScanPosition = evnt.OriginalPosition.Value;
@@ -527,6 +681,13 @@ public class LinkerService : ILinkerService, IAsyncDisposable
             return;
         }
 
+        if (eventNumber == 0 && !IsAdjustedStream(streamId))
+        {
+            _lastWrittenPerStream[streamId] = null;
+            _logger.LogDebug("{Name}: Tracking new stream {StreamId} optimistically from event 0", Name, streamId);
+            return;
+        }
+
         var lastInDest = await GetLastEventFromAStreamAsync(streamId);
         if (lastInDest != null)
         {
@@ -541,7 +702,7 @@ public class LinkerService : ILinkerService, IAsyncDisposable
             _lastWrittenPerStream[streamId] = null; // Mark as ready but not written yet
             _logger.LogDebug("{Name}: Initialized empty stream {StreamId}, ready to replicate event 0", Name, streamId);
         }
-        else if (_adjustedStartStreams.Contains(streamId))
+        else if (IsAdjustedStream(streamId))
         {
             _lastWrittenPerStream[streamId] = eventNumber - 1;
             _flusherForStreamPositions.Update(streamId, eventNumber - 1);
@@ -581,7 +742,7 @@ public class LinkerService : ILinkerService, IAsyncDisposable
                 {
                     expectedRevision = StreamState.StreamRevision(lastEventNumber);
                 }
-                else if (_adjustedStartStreams.Contains(evt.StreamId))
+                else if (IsAdjustedStream(evt.StreamId))
                 {
                     _logger.LogWarning($"{Name}: Skipping gap in adjusted stream {evt.StreamId}. Got {eventNumber}, expected {lastEventNumber + 1}");
                     await UpdateStreamTrackingAsync(evt);
@@ -598,7 +759,7 @@ public class LinkerService : ILinkerService, IAsyncDisposable
                     throw new InvalidOperationException($"Out-of-order event detected in {evt.StreamId}. Expected {lastEventNumber + 1}, got {eventNumber}.");
                 }
             }
-            else if (_adjustedStartStreams.Contains(evt.StreamId))
+            else if (IsAdjustedStream(evt.StreamId))
             {
                 _logger.LogInformation($"{Name}: Stream {evt.StreamId} is empty but adjusted start is enabled — using StreamState.NoStream for event {eventNumber}");
                 expectedRevision = StreamState.NoStream;
@@ -612,7 +773,7 @@ public class LinkerService : ILinkerService, IAsyncDisposable
                 }
                 else
                 {
-                    var isAdjusted = _adjustedStartStreams.Contains(evt.StreamId);
+                    var isAdjusted = IsAdjustedStream(evt.StreamId);
                     _lastWrittenPerStream.TryGetValue(evt.StreamId, out var lastWritten);
 
                     _logger.LogWarning($"{Name}: Debug — about to append event {eventNumber}@{evt.StreamId}, adjusted={isAdjusted}, lastWritten={lastWritten}");
@@ -627,7 +788,7 @@ public class LinkerService : ILinkerService, IAsyncDisposable
             {
                 expectedRevision = StreamState.NoStream;
             }
-            else if (_adjustedStartStreams.Contains(evt.StreamId))
+            else if (IsAdjustedStream(evt.StreamId))
             {
                 _logger.LogDebug($"{Name}: Stream {evt.StreamId} missing but start adjusted — using StreamState.NoStream for event {eventNumber}");
                 expectedRevision = StreamState.NoStream;
@@ -739,8 +900,11 @@ public class LinkerService : ILinkerService, IAsyncDisposable
         Interlocked.Increment(ref _replicatedSinceLastStats);
         Interlocked.Increment(ref _replicatedTotal);
 
-        if (_adjustedStartStreams.Remove(streamId))
-            await _adjustedStreamRepository.SaveAsync(_adjustedStartStreams);
+        bool removed;
+        lock (_adjustedLock)
+            removed = _adjustedStartStreams.Remove(streamId);
+        if (removed)
+            await SaveAdjustedStreamsAsync();
     }
 
     private async Task<ResolvedEvent?> GetLastEventFromAStreamAsync(string streamId)


### PR DESCRIPTION
## Summary

 Three changes that came out of running a per-tenant backfill (metadata-filtered `SubscribeToAll` over a ~122 GB `$all` store): catch-up replication silently stalled and never recovered, gave no usable progress signal, and was orders of magnitude slower than the destination could accept.

## 1. Resubscribe on subscription drop — fixes silent replication stalls (6d8a03f)

The `$all` catch-up subscription ran as a single unsupervised `await foreach` launched fire-and-forget, so any transient gRPC fault killed it as an unobserved exception: no log, no restart, replication permanently idle until the pod was bounced.

- `SubscribeMeGrpc` is now a supervised resubscribe loop: on any drop it logs a warning and resubscribes from the last saved position after a 5s backoff; genuine cancellation exits cleanly. Clean (no-exception) completion of the message stream also logs and backs off rather than tight-looping.
- `ResizeChannelAsync` now recreates the CancellationTokenSource before restarting workers — previously any adaptive-tuning buffer resize handed the new subscription/processing tasks an already-cancelled token, silently killing replication.
- `_lastPosition` (a 16-byte struct, non-atomic) is now read/written through a lock-guarded property, since the resubscribe loop reads it concurrently with the append path writing it; a torn read could have resumed from a garbage position and skipped events.
- Stale duplicate entries left in the per-stream buffers by post-resubscribe re-delivery are purged instead of retained indefinitely.

Resubscribing from the last position cannot duplicate events: the per-stream `_lastWrittenPerStream` dedup check is unchanged.


## 2. Real progress reporting during catch-up (e594302)

Progress was previously derived from the last *appended* event position, which sits frozen while a filtered scan sweeps non-matching regions — and the stats line was suppressed entirely whenever nothing had replicated recently, which is exactly when visibility mattered. It was impossible to tell a working scan from a dead one.

- The subscription now consumes `AllStreamCheckpointReached` messages into a scan position, giving true global catch-up progress independent of filter matches, plus `CaughtUp`/`FellBehind` transitions (status shows `live` once caught up).
- Stats log every interval, always: `catching up X%`, a smoothed ETA, replicated counts, buffer fill, and append latency. If the scan position stops moving the line says `STALLED (no scan progress for Ns)` explicitly.
- Adaptive-tuning chatter demoted to Debug unless a resize actually happens; the origin end position is refreshed periodically so progress tracks a growing origin.

## 3. Batched, parallel appends — removes the throughput bottleneck (98fb952)

Every replicated event previously cost two serial round trips (a backwards read of the destination stream to derive `expectedRevision`, then a single-event append), one event at a time: ~4.5 events/s observed.

- The channel now drains in cycles: events are staged into per-stream buffers and each stream's consecutive run is appended in one `AppendToStreamAsync` call (chunked at 100 events / 256 KB to stay under the server's append size limit), with `expectedRevision` computed from the tracked per-stream position instead of a read.
- Up to 8 streams append concurrently per cycle; ordering is preserved per stream, and the global checkpoint advances once per cycle to the max appended position (a crash mid-cycle replays at most one cycle, absorbed by dedup).
- New streams first seen at event 0 are tracked optimistically without a destination read. If tracking is ever stale, the `WrongExpectedVersion` handler re-reads the destination's actual head, repairs the tracked position, drops already-written events, and retries — self-healing with no duplicate appends; persistent conflicts fall back to the original event-by-event path with its full edge-case handling (adjusted streams, `$$` streams, tombstones, conflict handling).
- Removed the 100ms-per-event backpressure sleep (the bounded channel's blocking `WriteAsync` is the backpressure) and made the adjusted-streams set thread-safe now that drains run in parallel.

Observed result on a tenant backfill: from ~4 events/s (ETA measured in days) to catching up 31.8k events in ~23 minutes, ending in `live` tailing.

 
## Test plan

- `dotnet build` clean; all unit tests pass (14 passed, 1 skipped).
- Verified live against a local db01 → db02 tenant migration: resubscribe path observed firing and recovering; a full tenant backfill ran to completion and switched to `live`; destination stream heads spot-checked against origin.